### PR TITLE
refactor(operator): fill from contract latest block

### DIFF
--- a/contracts/src/EigenLayerBeaconOracle.sol
+++ b/contracts/src/EigenLayerBeaconOracle.sol
@@ -14,6 +14,9 @@ contract EigenLayerBeaconOracle is IBeaconChainOracle {
     /// @dev This is 1 day worth of slots.
     uint256 internal constant MAX_SLOT_ATTEMPTS = 7200;
 
+    /// @notice The size of the beacon block root ring buffer.
+    uint256 internal constant BUFFER_LENGTH = 8191;
+
     /// @notice The timestamp to block root mapping.
     mapping(uint256 => bytes32) public timestampToBlockRoot;
 
@@ -38,7 +41,7 @@ contract EigenLayerBeaconOracle is IBeaconChainOracle {
 
     function addTimestamp(uint256 _targetTimestamp) external {
         // If the targetTimestamp is not guaranteed to be within the beacon block root ring buffer, revert.
-        if ((block.timestamp - _targetTimestamp) >= (8190 * 12)) {
+        if ((block.timestamp - _targetTimestamp) >= (BUFFER_LENGTH * 12)) {
             revert TimestampOutOfRange();
         }
 

--- a/contracts/src/EigenLayerBeaconOracle.sol
+++ b/contracts/src/EigenLayerBeaconOracle.sol
@@ -26,6 +26,9 @@ contract EigenLayerBeaconOracle is IBeaconChainOracle {
     /// @notice Block timestamp does not correspond to a valid slot.
     error InvalidBlockTimestamp();
 
+    /// @notice Timestamp out of range.
+    error TimestampOutOfRange();
+
     constructor(
         uint256 _genesisBlockTimestamp
     ) {
@@ -34,6 +37,11 @@ contract EigenLayerBeaconOracle is IBeaconChainOracle {
     }
 
     function addTimestamp(uint256 _targetTimestamp) external {
+        // If the block is more than 1 day old, revert.
+        if ((block.timestamp - _targetTimestamp) >= (MAX_SLOT_ATTEMPTS * 12)) {
+            revert TimestampOutOfRange();
+        }
+
         // If _targetTimestamp corresponds to slot n, then the block root for slot n - 1 is returned.
         (bool success, ) = BEACON_ROOTS.staticcall(abi.encode(_targetTimestamp));
 

--- a/contracts/src/EigenLayerBeaconOracle.sol
+++ b/contracts/src/EigenLayerBeaconOracle.sol
@@ -37,8 +37,8 @@ contract EigenLayerBeaconOracle is IBeaconChainOracle {
     }
 
     function addTimestamp(uint256 _targetTimestamp) external {
-        // If the block is more than 1 day old, revert.
-        if ((block.timestamp - _targetTimestamp) >= (MAX_SLOT_ATTEMPTS * 12)) {
+        // If the targetTimestamp is not guaranteed to be within the beacon block root ring buffer, revert.
+        if ((block.timestamp - _targetTimestamp) >= (8190 * 12)) {
             revert TimestampOutOfRange();
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,6 @@ async fn main() -> Result<(), anyhow::Error> {
             }
         }
         // Sleep for 1 minute.
-        let _ = tokio::time::sleep(tokio::time::Duration::from_secs((5) as u64)).await;
+        let _ = tokio::time::sleep(tokio::time::Duration::from_secs((60) as u64)).await;
     }
 }


### PR DESCRIPTION
The operator should attempt to post updates starting from the latest block posted to the contract or 1 day ago. With this PR, the operator is now resilient to downtime within 1D.